### PR TITLE
refactor: 노트 API 서브컬렉션 방식으로 변경

### DIFF
--- a/note-service.js
+++ b/note-service.js
@@ -1,7 +1,5 @@
-const { admin, firestore } = require("./firebase-admin-config");
+const { firestore } = require("./firebase-admin-config");
 const { FieldValue } = require("firebase-admin/firestore");
-
-const NOTES_COLLECTION = "studyNotes";
 
 /**
  * 학습 노트 생성
@@ -10,17 +8,33 @@ async function createNote(note) {
   try {
     console.log("노트 저장 시도:", JSON.stringify(note));
 
+    if (!note.userId) {
+      throw new Error("사용자 ID가 필요합니다.");
+    }
+
     // 직렬화 가능한 형태로 데이터 정리
     const cleanedNote = JSON.parse(JSON.stringify(note));
 
-    const docRef = await firestore.collection(NOTES_COLLECTION).add({
-      ...cleanedNote,
-      createdAt: admin.firestore.FieldValue.serverTimestamp(),
-      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    // 서브컬렉션 방식으로 변경: users/{userId}/notes/{noteId}
+    const userNotesRef = firestore
+      .collection("users")
+      .doc(note.userId)
+      .collection("notes");
+
+    // userId 필드는 서브컬렉션에 포함하지 않음 (경로에 이미 포함)
+    const { userId, ...noteData } = cleanedNote;
+
+    const docRef = await userNotesRef.add({
+      ...noteData,
+      createdAt: FieldValue.serverTimestamp(),
+      updatedAt: FieldValue.serverTimestamp(),
     });
 
+    console.log("노트 저장 성공. 문서 ID:", docRef.id);
     return docRef.id;
   } catch (error) {
+    console.error("노트 생성 중 오류 상세:", error);
+    console.error("오류 스택:", error.stack);
     throw new Error(`노트 생성 중 오류가 발생했습니다: ${error.message}`);
   }
 }
@@ -30,11 +44,12 @@ async function createNote(note) {
  */
 async function getUserNotes(userId) {
   try {
-    const snapshot = await firestore
-      .collection(NOTES_COLLECTION)
-      .where("userId", "==", userId)
-      .orderBy("createdAt", "desc") // 생성일 기준 내림차순
-      .get();
+    // 서브컬렉션에서 사용자의 노트 조회
+    const userNotesRef = firestore
+      .collection("users")
+      .doc(userId)
+      .collection("notes");
+    const snapshot = await userNotesRef.orderBy("createdAt", "desc").get();
 
     return snapshot.docs.map((doc) => {
       const data = doc.data();
@@ -49,6 +64,7 @@ async function getUserNotes(userId) {
 
       return {
         id: doc.id,
+        userId, // 클라이언트 측 호환성을 위해 userId 추가
         ...data,
         createdAt,
         updatedAt,
@@ -63,10 +79,15 @@ async function getUserNotes(userId) {
 /**
  * 특정 학습 노트 조회
  */
-async function getNoteById(noteId) {
+async function getNoteById(userId, noteId) {
   try {
-    const docRef = firestore.collection(NOTES_COLLECTION).doc(noteId);
-    const docSnap = await docRef.get();
+    // 서브컬렉션에서 특정 노트 조회
+    const noteRef = firestore
+      .collection("users")
+      .doc(userId)
+      .collection("notes")
+      .doc(noteId);
+    const docSnap = await noteRef.get();
 
     if (docSnap.exists) {
       const data = docSnap.data();
@@ -81,6 +102,7 @@ async function getNoteById(noteId) {
 
       return {
         id: docSnap.id,
+        userId, // 클라이언트 측 호환성을 위해 userId 추가
         ...data,
         createdAt,
         updatedAt,
@@ -96,14 +118,22 @@ async function getNoteById(noteId) {
 /**
  * 학습 노트 업데이트
  */
-async function updateNote(noteId, noteData) {
+async function updateNote(userId, noteId, noteData) {
   try {
     // 직렬화 가능한 형태로 데이터 정리
     const cleanedNoteData = JSON.parse(JSON.stringify(noteData));
 
-    const docRef = firestore.collection(NOTES_COLLECTION).doc(noteId);
-    await docRef.update({
-      ...cleanedNoteData,
+    // userId 필드 제거 (경로에 이미 포함)
+    const { userId: _, ...updateData } = cleanedNoteData;
+
+    // 서브컬렉션의 노트 업데이트
+    const noteRef = firestore
+      .collection("users")
+      .doc(userId)
+      .collection("notes")
+      .doc(noteId);
+    await noteRef.update({
+      ...updateData,
       updatedAt: FieldValue.serverTimestamp(),
     });
     return true;
@@ -116,10 +146,15 @@ async function updateNote(noteId, noteData) {
 /**
  * 학습 노트 삭제
  */
-async function deleteNote(noteId) {
+async function deleteNote(userId, noteId) {
   try {
-    const docRef = firestore.collection(NOTES_COLLECTION).doc(noteId);
-    await docRef.delete();
+    // 서브컬렉션의 노트 삭제
+    const noteRef = firestore
+      .collection("users")
+      .doc(userId)
+      .collection("notes")
+      .doc(noteId);
+    await noteRef.delete();
     return true;
   } catch (error) {
     console.error("노트 삭제 중 오류:", error);

--- a/server.js
+++ b/server.js
@@ -30,7 +30,6 @@ app.get("/health", (req, res) => {
 });
 
 // 노트 API 엔드포인트
-// 노트 생성 API
 app.post("/api/note", async (req, res) => {
   try {
     const data = req.body;
@@ -47,7 +46,7 @@ app.post("/api/note", async (req, res) => {
   }
 });
 
-// 노트 목록 조회 API
+// 노트 목록 조회 API - 변경 없음
 app.get("/api/note", async (req, res) => {
   try {
     const userId = req.query.userId;
@@ -66,11 +65,17 @@ app.get("/api/note", async (req, res) => {
   }
 });
 
-// 노트 상세 조회 API
+// 노트 상세 조회 API - userId 파라미터 추가
 app.get("/api/note/:id", async (req, res) => {
   try {
     const noteId = req.params.id;
-    const note = await noteService.getNoteById(noteId);
+    const userId = req.query.userId; // 쿼리 파라미터에서 userId 가져오기
+
+    if (!userId) {
+      return res.status(400).json({ error: "사용자 ID가 필요합니다." });
+    }
+
+    const note = await noteService.getNoteById(userId, noteId);
 
     if (!note) {
       return res.status(404).json({ error: "노트를 찾을 수 없습니다." });
@@ -85,13 +90,18 @@ app.get("/api/note/:id", async (req, res) => {
   }
 });
 
-// 노트 업데이트 API
+// 노트 업데이트 API - userId 파라미터 추가
 app.put("/api/note/:id", async (req, res) => {
   try {
     const noteId = req.params.id;
     const noteData = req.body;
+    const userId = noteData.userId; // 요청 본문에서 userId 가져오기
 
-    await noteService.updateNote(noteId, noteData);
+    if (!userId) {
+      return res.status(400).json({ error: "사용자 ID가 필요합니다." });
+    }
+
+    await noteService.updateNote(userId, noteId, noteData);
     return res.json({ success: true });
   } catch (error) {
     console.error("노트 업데이트 API 오류:", error);
@@ -101,11 +111,17 @@ app.put("/api/note/:id", async (req, res) => {
   }
 });
 
-// 노트 삭제 API
+// 노트 삭제 API - userId 파라미터 추가
 app.delete("/api/note/:id", async (req, res) => {
   try {
     const noteId = req.params.id;
-    await noteService.deleteNote(noteId);
+    const userId = req.query.userId; // 쿼리 파라미터에서 userId 가져오기
+
+    if (!userId) {
+      return res.status(400).json({ error: "사용자 ID가 필요합니다." });
+    }
+
+    await noteService.deleteNote(userId, noteId);
     return res.json({ success: true });
   } catch (error) {
     console.error("노트 삭제 API 오류:", error);


### PR DESCRIPTION
# 노트 관련 API를 서브컬렉션 방식으로 변경

### 특정유저가 쓴 노트를 찾기 위해선 Firestore의 쿼리 기능을 사용해 특정 사용자의 노트를 필터링 해야함 
```(where('userId', '==', '1')) ``` 로 매번 노트전체를 탐색해야함

이 부분이 사용자별 노트를 조회할 때 항상 필터링이 필요하다는 점에서 수정하기로 함

## 변경전

![이전버전](https://github.com/user-attachments/assets/8088466d-7936-4425-8c6b-c12d77995658)

note라는 루트 컬렉션 안에 각각 노트 아이디 안에 객체로 유저 아이디가 저장되어있던 방식

notes/{noteId} 구조안에  userId 필드 존재함

ex) 

```json

note {

1234 {
  userId : 1,
  ...
},

12345 {
  userId : 2,
  ...
},
12346 {
  userId : 1,
  ...
}
}

```



-------

## 수정후

![수정후 1](https://github.com/user-attachments/assets/66b61f51-0e7c-4e53-9823-8d87c9cfc174)
![수정후 2](https://github.com/user-attachments/assets/75cd5129-30f7-4ae4-8e5b-112cb9c1dc6d)
![수정후 3](https://github.com/user-attachments/assets/d63657e6-fec3-490f-ba7b-8309c2145c4d)


수정후 방식은 user라는 최상위 필드에서 유저아이디 별로 각각 노트를 저장하는 방식

 ```users/{userId}/notes/{noteId}``` 데이터 구조 형식
 
 
```json

user {

  1234(userId) {
      note {
      id : 2,
      ...
}
},
   456(userId) {
      note {
      id : 3,
      ...
}

```

이 방식이 추후 사용자별로 퀴즈리스트 혹은 다른 정보를 저장하기에도 용이해보여서 수정